### PR TITLE
Updated test coverage on Linux

### DIFF
--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,11 +1,10 @@
 import XCTest
-@testable import guitarTests
+@testable import GuitarTests
 
 XCTMain([
-    testCase(GuitarTests.allTests),
     testCase(GuitarBooleanTests.allTests),
     testCase(GuitarCaseTests.allTests),
     testCase(GuitarCharacterTests.allTests),
     testCase(GuitarPaddingTests.allTests),
-    testCase(GuitarTrimmingTests.allTests),
+    testCase(GuitarTests.allTests),
 ])


### PR DESCRIPTION
- Capitalized the name of the imported module such that it can be compiled now.
- Removed the TrimmingTests line because that suite doesn't exist anymore.
- Reordered the lines to match the order of the files in the GuitarTests folder.