### PR TITLE
fix for characters not supported by utf8, such as some emoji

### DIFF
--- a/Sources/Guitar.swift
+++ b/Sources/Guitar.swift
@@ -43,7 +43,7 @@ public struct Guitar {
     ///
     /// - Returns: A list of matches.
     public func evaluateForRanges(from string: String, with options: NSRegularExpression.Options = []) -> [Range<String.Index>] {
-        let range = NSRange(location: 0, length: string.count)
+        let range = NSRange(location: 0, length: string.utf16.count)
         guard let regex = try? NSRegularExpression(pattern: pattern, options: options) else {
             return []
         }


### PR DESCRIPTION
In swift, the count function of string uses utf8 by default. In this case, when you encounter some utf16 characters, the result returned by count function is problematic, but there is no such problem in OC, NSString length() default  is utf16.